### PR TITLE
Avoid parental rating dialogs on some CAMs

### DIFF
--- a/server/livestreamer.c
+++ b/server/livestreamer.c
@@ -48,7 +48,11 @@ cStreamdevLiveReceiver::cStreamdevLiveReceiver(cStreamdevLiveStreamer *Streamer,
 {
 		// clears all PIDs but channel remains set
 		SetPids(NULL);
-		AddPids(Pids);
+		if(Pids) {
+			for(;*Pids;Pids++) {
+				if(*Pids != 18) AddPid(*Pids);
+			}
+		}
 }
 
 cStreamdevLiveReceiver::~cStreamdevLiveReceiver()


### PR DESCRIPTION
This change was originally made by @ciminus. As this VDR plugin is now "community maintained" (meaning there is no single person who actively maintains it) and, so far, I don't really understand what this change is for, I decided to put it into a Pull Request so this information is not lost and some discussion around it can happen here.

What I've found out, so far, is that this change may be related to parental rating dialogs popping up on the VDR **server** if a client requests such channels. This would mean someone has to walk to the server and somehow interact with this message. Good luck for a headless VDR server which probably displays this message into "nothing".

- Is this a change everyone wants to have or should this have a configuration switch in the plugin settings?
- What is this magic number "18" about? Where does it come from? Can this be placed to a constant or #define? I'm not a big fan of some unnamed magic numbers in code.
- Oh, and why is it no option to just go to the CAM configuration and disable parental rating there?