### PR TITLE
support the NULL Channel in SetChannelDevice

### DIFF
--- a/client/device.c
+++ b/client/device.c
@@ -159,6 +159,7 @@ bool cStreamdevDevice::ProvidesChannel(const cChannel *Channel, int Priority,
 
 bool cStreamdevDevice::SetChannelDevice(const cChannel *Channel,
 		bool LiveView) {
+	if (!Channel) return true;
 	bool res;
 	Dprintf("SetChannelDevice Channel: %s, LiveView: %s\n", Channel->Name(),
 			LiveView ? "true" : "false");


### PR DESCRIPTION
See:

https://www.vdr-portal.de/forum/index.php?thread/136284-patch-unbenutzte-frontends-schlie%C3%9Fen/&postID=1371712#post1371712

   virtual bool SetChannelDevice(const cChannel *Channel, bool LiveView);
          ///< Sets the device to the given channel (actual physical setup).
         ///< If Channel is NULL, this means the device is no longer needed and may
         ///< turn itself into a power saving mode, if possible. The device must,
         ///< however, be ready for the next call with a non-NULL Channel at any
         ///< time.