### PR TITLE
make LSTE work over VTP for modern VDR versions

### DIFF
--- a/server/connectionVTP.c
+++ b/server/connectionVTP.c
@@ -74,6 +74,10 @@ cLSTEHandler::cLSTEHandler(cConnectionVTP *Client, const char *Option):
 	eDumpModeStreamdev dumpmode = dmsdAll;
 	time_t attime = 0;
 	time_t fromtime = 0;
+#if APIVERSNUM >= 20300
+	LOCK_SCHEDULES_READ;
+	m_Schedules = Schedules;
+#endif
 
 	if (m_Schedules != NULL && *Option) {
 		char buf[strlen(Option) + 1];


### PR DESCRIPTION
This patch adds the missing LOCK_SCHEDULES_READ to access the EPG data.