### PR TITLE
fix deprecated warning with DelByName. lock is already taken

### DIFF
--- a/server/connectionVTP.c
+++ b/server/connectionVTP.c
@@ -2032,7 +2032,11 @@ bool cConnectionVTP::CmdDELR(const char *Option)
 				if (!rc) {
 					if (recording->Delete()) {
 						Reply(250, "Recording \"%s\" deleted", Option);
-#if APIVERSNUM >= 20300
+#if APIVERSNUM >= 20304
+						LOCK_DELETEDRECORDINGS_WRITE;
+						Recordings->Del(recording, false);
+						DeletedRecordings->Add(recording);
+#elif APIVERSNUM >= 20300
 						Recordings->DelByName(recording->FileName());
 #else
 						::Recordings.DelByName(recording->FileName());


### PR DESCRIPTION
fixes:
```c

connectionVTP.c: In member function 'bool cConnectionVTP::CmdDELR(const char*)': connectionVTP.c:2036:70: warning: 'void cRecordings::DelByName(const char*)' is deprecated: use explicit locking, deleting etc. [-Wdeprecated-declarations]
 2036 |                                                 Recordings->DelByName(recording->FileName());
      |                                                 ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
In file included from /var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/vdr-2.8.1/skins.h:18,
                 from /var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/vdr-2.8.1/osdbase.h:15,
                 from /var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/vdr-2.8.1/menuitems.h:15,
                 from /var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/vdr-2.8.1/plugin.h:14,
                 from ../common.h:15,
                 from ../server/connection.h:9,
                 from ../server/connectionVTP.h:4,
                 from connectionVTP.c:5:
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/build/vdr-2.8.1/recording.h:314:62: note: declared here
  314 |   [[deprecated("use explicit locking, deleting etc.")]] void DelByName(const char *FileName);
      |                                                              ^~~~~~~~~
``` 