### PR TITLE
i18n: fix parallel install race on locale directory creation

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -65,7 +65,7 @@ $(I18Npot): $(CLIENTOBJS:%.o=%.c)
 
 $(I18Nmsgs): $(DESTDIR)$(LOCDIR)/%/LC_MESSAGES/vdr-$(PLUGIN).mo: $(PODIR)/%.mo
 	@echo IN client/ $@
-	$(Q)install -D -m644 $< $@
+	$(Q)mkdir -p $(dir $@) && install -m644 $< $@
 
 .PHONY: i18n
 i18n: $(I18Nmo) $(I18Npot)

--- a/server/Makefile
+++ b/server/Makefile
@@ -70,7 +70,7 @@ $(I18Npot): $(SERVEROBJS:%.o=%.c)
 
 $(I18Nmsgs): $(DESTDIR)$(LOCDIR)/%/LC_MESSAGES/vdr-$(PLUGIN).mo: $(PODIR)/%.mo
 	@echo IN server/ $@
-	$(Q)install -D -m644 $< $@
+	$(Q)mkdir -p $(dir $@) && install -m644 $< $@
 
 .PHONY: i18n
 i18n: $(I18Nmo) $(I18Npot)


### PR DESCRIPTION
install -D is not atomic: concurrent client and server install-i18n targets race to mkdir the same locale/*/LC_MESSAGES path and one fails. Use mkdir -p (idempotent under parallel make) then install without -D.

- fixes #9 